### PR TITLE
feat(compost): added first 5 demo functions

### DIFF
--- a/src/components/graph-sidebar.tsx
+++ b/src/components/graph-sidebar.tsx
@@ -92,37 +92,7 @@ export const GraphSidebar = () => {
 
             <P1>Render graphs based on your spreadsheet.</P1>
 
-            <AddedCellsContainer>
-                {Array.from(graphCells).map((cellId) => (
-                    <CellTag key={cellId}>{cellId}</CellTag>
-                ))}
-            </AddedCellsContainer>
-
-            <Graph>
-                {graphCells.size > 0 ? (
-                    <ResponsiveContainer width="100%" height="100%">
-                        <LineChart data={data}>
-                            <XAxis dataKey="x" />
-                            <YAxis domain={["dataMin - 10", "dataMax + 10"]} />
-
-                            <Tooltip />
-                            <Legend />
-
-                            {Array.from(graphCells).map((cellId, index) => (
-                                <Line
-                                    type="monotone"
-                                    dataKey={cellId}
-                                    stroke={colors[index % colors.length]}
-                                    isAnimationActive={false}
-                                    key={cellId}
-                                />
-                            ))}
-                        </LineChart>
-                    </ResponsiveContainer>
-                ) : (
-                    <NoGraphData>No data to show...</NoGraphData>
-                )}
-            </Graph>
+            <GraphCanvas id="graphDisplay"></GraphCanvas>
         </Container>
     );
 };
@@ -188,38 +158,8 @@ const Graph = styled.div`
     border: 1px solid rgba(0, 0, 0, 0.05);
 `;
 
-const NoGraphData = styled.div`
-    color: var(--text-1);
-    font-size: 14px;
-    font-weight: 400;
-    line-height: 100%;
-`;
-
-const AddedCellsContainer = styled.div`
+const GraphCanvas = styled.div`
+    margin-top: 20px;
     width: 100%;
-
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 10px;
-
-    margin: 15px 0px;
-`;
-
-const CellTag = styled.div`
-    color: var(--text-1);
-    font-size: 10px;
-    font-weight: 400;
-    line-height: 100%;
-
-    padding: 8px 12px;
-
-    border-radius: 10px;
-    border: 1px solid rgba(0, 0, 0, 0.1);
-
-    background-color: rgba(0, 0, 0, 0.05);
-
-    cursor: pointer;
-
-    transition: all 100ms;
+    height: 90%;
 `;

--- a/src/components/spreadsheet/spreadsheet.component.tsx
+++ b/src/components/spreadsheet/spreadsheet.component.tsx
@@ -226,6 +226,7 @@ export function Spreadsheet() {
         },
         [graphCells],
     );
+
     // formula
 
     const getFormulaElement = () => {
@@ -625,7 +626,13 @@ export function Spreadsheet() {
 
         const newUsedCells = new Set<CellId>(usedCells);
         newUsedCells.delete(cellId);
+        removeCompostObjectFromCell(coords);
         setUsedCells(newUsedCells);
+    };
+
+    const removeCompostObjectFromCell = (coords: CellCoords) => {
+        const { ri, ci } = coords;
+        delete data[ri][ci].compostGraphValue;
     };
 
     const setCellIndicatorText = ({ ri, ci }: CellCoords) => {

--- a/src/components/spreadsheet/spreadsheet.component.tsx
+++ b/src/components/spreadsheet/spreadsheet.component.tsx
@@ -244,7 +244,7 @@ export function Spreadsheet() {
     const onFormulaEnter = () => {
         const coords = getFirstSelectedCell();
         const { formula } = data[coords.ri][coords.ci];
-
+        removeCompostObjectFromCell(coords);
         if (formula.trim() !== "") {
             addUsedCell(coords);
         } else {

--- a/src/components/spreadsheet/spreadsheet.component.tsx
+++ b/src/components/spreadsheet/spreadsheet.component.tsx
@@ -56,6 +56,7 @@ export function Spreadsheet() {
         graphCells,
         addGraphCell,
         removeGraphCell,
+        setGraphCells,
     } = useCellInfo();
 
     const { history, setHistory, dataHistory } = useHistory();
@@ -227,6 +228,20 @@ export function Spreadsheet() {
         [graphCells],
     );
 
+    useEffect(
+        function getGraphCells() {
+            const newGraphCells = new Set<CellId>();
+            for (const cellId of usedCells) {
+                const { ri, ci } = Utils.cellIdToCoords(cellId as CellId);
+                if (data[ri][ci].isInGraph === true) {
+                    newGraphCells.add(cellId as CellId);
+                }
+            }
+            setGraphCells(newGraphCells);
+        },
+        [usedCells],
+    );
+
     // formula
 
     const getFormulaElement = () => {
@@ -325,6 +340,7 @@ export function Spreadsheet() {
 
             data[ri][ci].formula = "";
             data[ri][ci].value = "";
+            data[ri][ci].isInGraph = false;
 
             getCellSpan({ ri, ci }).innerText = "";
             removeUsedCell({ ri, ci });
@@ -451,6 +467,7 @@ export function Spreadsheet() {
         }
 
         const { formula } = data[ri][ci];
+
         setFormulaValue(formula);
 
         setCellIndicatorText({ ri, ci });

--- a/src/components/spreadsheet/spreadsheet.model.ts
+++ b/src/components/spreadsheet/spreadsheet.model.ts
@@ -1,9 +1,11 @@
+import { GraphValue, Value } from "@/runtime/runtime";
 export type SpreadsheetCell = {
     formula: string;
     value: string;
     color?: string;
     font?: string[];
     isInGraph?: boolean;
+    compostGraphValue?: GraphValue;
 };
 
 export type SpreadsheetRow = SpreadsheetCell[];

--- a/src/components/spreadsheet/spreadsheet.model.ts
+++ b/src/components/spreadsheet/spreadsheet.model.ts
@@ -5,7 +5,7 @@ export type SpreadsheetCell = {
     color?: string;
     font?: string[];
     isInGraph?: boolean;
-    compostGraphValue?: GraphValue;
+    compostGraphValue?: GraphValue[];
 };
 
 export type SpreadsheetRow = SpreadsheetCell[];

--- a/src/components/toolbar.component.tsx
+++ b/src/components/toolbar.component.tsx
@@ -416,14 +416,7 @@ const ImportExportTab = () => {
         for (let ri = 0; ri < data.length; ri++) {
             for (let ci = 0; ci < data[ri].length; ci++) {
                 const cellId = Utils.cellCoordsToId({ ri, ci });
-                const {
-                    formula,
-                    value,
-                    color,
-                    font,
-                    isInGraph,
-                    compostGraphValue,
-                } = data[ri][ci];
+                const { formula, value, color, font, isInGraph } = data[ri][ci];
 
                 if (formula.trim() === "" && value.trim() === "") {
                     continue;
@@ -436,7 +429,6 @@ const ImportExportTab = () => {
                     font,
                     isInGraph,
                     history,
-                    compostGraphValue,
                 };
             }
         }
@@ -482,14 +474,7 @@ const ImportExportTab = () => {
         const newDataHistory = new Map(dataHistory);
 
         for (const [cellId, cellData] of Object.entries(importedData)) {
-            const {
-                formula,
-                value,
-                color,
-                font,
-                isInGraph,
-                compostGraphValue,
-            } = cellData as any;
+            const { formula, value, color, font, isInGraph } = cellData as any;
             const { ri, ci } = Utils.cellIdToCoords(cellId as CellId);
 
             data[ri][ci].formula = formula;
@@ -497,7 +482,6 @@ const ImportExportTab = () => {
             data[ri][ci].color = color;
             data[ri][ci].font = font;
             data[ri][ci].isInGraph = isInGraph;
-            data[ri][ci].compostGraphValue = compostGraphValue;
 
             if (color) {
                 newCellColors.set(cellId as CellId, color);

--- a/src/components/toolbar.component.tsx
+++ b/src/components/toolbar.component.tsx
@@ -416,7 +416,14 @@ const ImportExportTab = () => {
         for (let ri = 0; ri < data.length; ri++) {
             for (let ci = 0; ci < data[ri].length; ci++) {
                 const cellId = Utils.cellCoordsToId({ ri, ci });
-                const { formula, value, color, font, isInGraph } = data[ri][ci];
+                const {
+                    formula,
+                    value,
+                    color,
+                    font,
+                    isInGraph,
+                    compostGraphValue,
+                } = data[ri][ci];
 
                 if (formula.trim() === "" && value.trim() === "") {
                     continue;
@@ -429,6 +436,7 @@ const ImportExportTab = () => {
                     font,
                     isInGraph,
                     history,
+                    compostGraphValue,
                 };
             }
         }
@@ -474,7 +482,14 @@ const ImportExportTab = () => {
         const newDataHistory = new Map(dataHistory);
 
         for (const [cellId, cellData] of Object.entries(importedData)) {
-            const { formula, value, color, font, isInGraph } = cellData as any;
+            const {
+                formula,
+                value,
+                color,
+                font,
+                isInGraph,
+                compostGraphValue,
+            } = cellData as any;
             const { ri, ci } = Utils.cellIdToCoords(cellId as CellId);
 
             data[ri][ci].formula = formula;
@@ -482,6 +497,7 @@ const ImportExportTab = () => {
             data[ri][ci].color = color;
             data[ri][ci].font = font;
             data[ri][ci].isInGraph = isInGraph;
+            data[ri][ci].compostGraphValue = compostGraphValue;
 
             if (color) {
                 newCellColors.set(cellId as CellId, color);

--- a/src/runtime/evaluator.ts
+++ b/src/runtime/evaluator.ts
@@ -26,7 +26,13 @@ export class Evaluator {
         const formula =
             step === 0 ? (defaultFormula ?? primaryFormula) : primaryFormula;
 
-        return this.evaluateFormula(formula, step, history, dataHistory);
+        return this.evaluateFormula(
+            formula,
+            step,
+            history,
+            dataHistory,
+            cellId,
+        );
     }
 
     private evaluateFormula(
@@ -34,6 +40,7 @@ export class Evaluator {
         step: number,
         history: History,
         dataHistory: History,
+        cellId: CellId,
     ): string {
         try {
             const expression = new Parser().parse(formula);
@@ -42,6 +49,7 @@ export class Evaluator {
                 step,
                 history,
                 dataHistory,
+                cellId,
             );
             return result;
         } catch (e) {

--- a/src/runtime/functions.ts
+++ b/src/runtime/functions.ts
@@ -727,6 +727,66 @@ export namespace Functions {
         return createNumber(step);
     };
 
+    // graph scale functions
+
+    export const scalecontinuous = ({ args, cellId }: FuncProps): Value => {
+        const min = expectNumber(args, 0).value;
+        const max = expectNumber(args, 1).value;
+
+        const result = s.continuous(min, max) as CompostObject;
+        const output = createGraphValue(result);
+        saveGraphValue(output, cellId);
+        return createGraphId("continuous scale", cellId);
+    };
+
+    export const scale = ({ args, cellId }: FuncProps): Value => {
+        const scale1 = getGraphValueFromGraphId(
+            expectString(args, 0).value as GraphId,
+        ).value;
+        const scale2 = getGraphValueFromGraphId(
+            expectString(args, 1).value as GraphId,
+        ).value;
+        const shape = getGraphValueFromGraphId(
+            expectString(args, 2).value as GraphId,
+        ).value;
+
+        const result = c.scale(scale1, scale2, shape) as CompostObject;
+        const output = createGraphValue(result);
+
+        saveGraphValue(output, cellId);
+        return createGraphId("scale", cellId);
+    };
+
+    export const scaleY = ({ args, cellId }: FuncProps): Value => {
+        const scale = getGraphValueFromGraphId(
+            expectString(args, 0).value as GraphId,
+        ).value;
+        const shape = getGraphValueFromGraphId(
+            expectString(args, 1).value as GraphId,
+        ).value;
+
+        const result = c.scaleY(scale, shape) as CompostObject;
+        const output = createGraphValue(result);
+
+        saveGraphValue(output, cellId);
+        return createGraphId("scaleY", cellId);
+    };
+
+    export const scaleX = ({ args, cellId }: FuncProps): Value => {
+        const scale = getGraphValueFromGraphId(
+            expectString(args, 0).value as GraphId,
+        ).value;
+        const shape = getGraphValueFromGraphId(
+            expectString(args, 1).value as GraphId,
+        ).value;
+
+        const result = c.scaleX(scale, shape) as CompostObject;
+        const output = createGraphValue(result);
+
+        saveGraphValue(output, cellId);
+        return createGraphId("scaleX", cellId);
+    };
+
     // graph functions
 
     export const column = ({ args, cellId }: FuncProps): Value => {
@@ -738,6 +798,19 @@ export namespace Functions {
 
         saveGraphValue(output, cellId);
         return createGraphId("column", cellId);
+    };
+
+    export const bubble = ({ args, cellId }: FuncProps): Value => {
+        const x = expectNumber(args, 0).value;
+        const y = expectNumber(args, 1).value;
+        const width = expectNumber(args, 2).value;
+        const height = expectNumber(args, 3).value;
+
+        const result = c.bubble(x, y, width, height) as CompostObject;
+        const output = createGraphValue(result);
+
+        saveGraphValue(output, cellId);
+        return createGraphId("bubble", cellId);
     };
 
     export const axes = ({ args, cellId }: FuncProps): Value => {

--- a/src/runtime/functions.ts
+++ b/src/runtime/functions.ts
@@ -866,13 +866,29 @@ export namespace Functions {
 
     export const overlay = ({ args, cellId, step }: FuncProps): Value => {
         const shapes: CompostObject[] = [];
+
         for (let i = 0; i < args.length; i++) {
-            const shape = getGraphValueFromGraphId(
-                expectString(args, i).value as GraphId,
-                step,
-            ).value;
-            shapes.push(shape);
+            if (args[i].type == ValueType.String) {
+                const shape = getGraphValueFromGraphId(
+                    expectString(args, i).value as GraphId,
+                    step,
+                ).value;
+                shapes.push(shape);
+            } else if (args[i].type == ValueType.CellRange) {
+                const range = expectCellRange(args, i).value;
+                const [c1, r1, c2, r2] = range;
+                for (let ri = r1; ri <= r2; ri++) {
+                    for (let ci = c1; ci <= c2; ci++) {
+                        const shape =
+                            data[ri][ci].compostGraphValue[step].value;
+                        shapes.push(shape);
+                    }
+                }
+            } else {
+                throw new Error("Function argument type mismatch.");
+            }
         }
+
         const result = c.overlay(shapes) as CompostObject;
         const output = createGraphValue(result);
         saveGraphValue(output, cellId, step);

--- a/src/runtime/runtime/model.ts
+++ b/src/runtime/runtime/model.ts
@@ -1,4 +1,4 @@
-import { History } from "@/components/spreadsheet/spreadsheet.model";
+import { CellId, History } from "@/components/spreadsheet/spreadsheet.model";
 
 export enum ValueType {
     Number,
@@ -6,6 +6,7 @@ export enum ValueType {
     String,
     CellLiteral,
     CellRange,
+    GraphValue,
 }
 
 export interface Value {
@@ -38,11 +39,21 @@ export interface CellRangeValue {
     value: number[];
 }
 
+export type GraphId = `${string} - ${CellId}`;
+
+export interface GraphValue {
+    type: ValueType.GraphValue;
+    value: CompostObject;
+}
+
+export type CompostObject = any;
+
 export type FuncProps = {
     args: Value[];
     step: number;
     history: History;
     dataHistory: History;
+    cellId: CellId;
 };
 
 export type FuncCall = (props: FuncProps) => Value;

--- a/src/runtime/runtime/runtime.ts
+++ b/src/runtime/runtime/runtime.ts
@@ -76,6 +76,12 @@ export class Runtime {
         ["OVERLAY", Functions.overlay],
         ["AXES", Functions.axes],
         ["FILLCOLOR", Functions.fillColor],
+        ["BUBBLE", Functions.bubble],
+
+        ["SCALECONTINUOUS", Functions.scalecontinuous],
+        ["SCALEY", Functions.scaleY],
+        ["SCALEX", Functions.scaleX],
+        ["SCALE", Functions.scale],
     ]);
 
     public run(

--- a/src/runtime/runtime/runtime.ts
+++ b/src/runtime/runtime/runtime.ts
@@ -72,25 +72,30 @@ export class Runtime {
         ["HISTORY", Functions.history],
         ["STEP", Functions.step],
 
-        ["COLUMN", Functions.column],
         ["RENDER", Functions.render],
         ["OVERLAY", Functions.overlay],
         ["AXES", Functions.axes],
-        ["FILLCOLOR", Functions.fillColor],
+
+        ["COLUMN", Functions.column],
         ["BUBBLE", Functions.bubble],
         ["LINE", Functions.line],
         ["SHAPE", Functions.shape],
-        ["STROKECOLOR", Functions.strokeColor],
         ["BAR", Functions.bar],
+        ["TEXT", Functions.text],
+
+        ["STROKECOLOR", Functions.strokeColor],
+        ["FONT", Functions.font],
+        ["FILLCOLOR", Functions.fillColor],
+        ["PADDING", Functions.padding],
 
         ["POINT", Functions.point],
         ["CATEGORICALCOORD", Functions.categoricalcoord],
         ["SCALECONTINUOUS", Functions.scalecontinuous],
+        ["SCALECATEGORICAL", Functions.scalecategorical],
         ["SCALEY", Functions.scaleY],
         ["SCALEX", Functions.scaleX],
         ["SCALE", Functions.scale],
-
-        ["TEST", Functions.test],
+        ["NEST", Functions.nest],
     ]);
 
     public run(

--- a/src/runtime/runtime/runtime.ts
+++ b/src/runtime/runtime/runtime.ts
@@ -104,7 +104,6 @@ export class Runtime {
         switch (result.type) {
             case ValueType.Number: {
                 const { value } = result as NumberValue;
-
                 if (Math.round(value) === value) {
                     return Math.round(value).toString();
                 }

--- a/src/runtime/runtime/runtime.ts
+++ b/src/runtime/runtime/runtime.ts
@@ -77,7 +77,9 @@ export class Runtime {
         ["AXES", Functions.axes],
         ["FILLCOLOR", Functions.fillColor],
         ["BUBBLE", Functions.bubble],
+        ["LINE", Functions.line],
 
+        ["POINT", Functions.point],
         ["SCALECONTINUOUS", Functions.scalecontinuous],
         ["SCALEY", Functions.scaleY],
         ["SCALEX", Functions.scaleX],

--- a/src/runtime/runtime/runtime.ts
+++ b/src/runtime/runtime/runtime.ts
@@ -25,11 +25,13 @@ import {
     Value,
     ValueType,
 } from "./model";
+import { data } from "@/components/spreadsheet/data";
 
 export class Runtime {
     private step: number;
     private history: History;
     private dataHistory: History;
+    private cellId: CellId;
 
     private inCallExpression: boolean = false;
 
@@ -68,6 +70,12 @@ export class Runtime {
         ["PREV", Functions.prev],
         ["HISTORY", Functions.history],
         ["STEP", Functions.step],
+
+        ["COLUMN", Functions.column],
+        ["RENDER", Functions.render],
+        ["OVERLAY", Functions.overlay],
+        ["AXES", Functions.axes],
+        ["FILLCOLOR", Functions.fillColor],
     ]);
 
     public run(
@@ -75,17 +83,18 @@ export class Runtime {
         step: number,
         history: History,
         dataHistory: History,
+        cellId: CellId,
     ) {
         this.step = step;
         this.history = history;
         this.dataHistory = dataHistory;
+        this.cellId = cellId;
 
         return this.runFormula(expression);
     }
 
     public runFormula(expression: Expression): string {
         const result = this.runExpression(expression);
-
         switch (result.type) {
             case ValueType.Number: {
                 const { value } = result as NumberValue;
@@ -169,6 +178,7 @@ export class Runtime {
             step: this.step,
             history: this.history,
             dataHistory: this.dataHistory,
+            cellId: this.cellId,
         });
     }
 

--- a/src/runtime/runtime/runtime.ts
+++ b/src/runtime/runtime/runtime.ts
@@ -26,6 +26,7 @@ import {
     ValueType,
 } from "./model";
 import { data } from "@/components/spreadsheet/data";
+import { FunnelChart } from "recharts";
 
 export class Runtime {
     private step: number;
@@ -78,12 +79,18 @@ export class Runtime {
         ["FILLCOLOR", Functions.fillColor],
         ["BUBBLE", Functions.bubble],
         ["LINE", Functions.line],
+        ["SHAPE", Functions.shape],
+        ["STROKECOLOR", Functions.strokeColor],
+        ["BAR", Functions.bar],
 
         ["POINT", Functions.point],
+        ["CATEGORICALCOORD", Functions.categoricalcoord],
         ["SCALECONTINUOUS", Functions.scalecontinuous],
         ["SCALEY", Functions.scaleY],
         ["SCALEX", Functions.scaleX],
         ["SCALE", Functions.scale],
+
+        ["TEST", Functions.test],
     ]);
 
     public run(

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -3,6 +3,7 @@ import {
     CellId,
     SpreadsheetData,
 } from "@/components/spreadsheet/spreadsheet.model";
+import { GraphId } from "@/runtime/runtime";
 
 export namespace Utils {
     export const getCellIdsFromFormula = (formula: string): CellId[] => {


### PR DESCRIPTION
Hi I've added the first 5 compost demo functions - column, fillcolor, render, overlay and axes - with that I've also added a system for passing the arguments since the whole system is restricted to passing only strings in the cells, I've decided to pass reference to the cell itself and It hold the value of the `CompostObject` in the `SpreadsheetCell` structure. It is just an idea and my take on how to approach the aforementioned restriction.